### PR TITLE
Script to upload to Oxide

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -4,3 +4,5 @@ apiVersion: v4
 outputFileName: index.html
 htmlTitle: Title
 branch: ~
+gitName:
+gitEmail:

--- a/package.json
+++ b/package.json
@@ -7,18 +7,22 @@
   "scripts": {
     "build": "webpack",
     "build:dev": "webpack --dev",
-    "upload": "webpack && node ./scripts/upload.js"
+    "upload": "yarn build && node ./scripts/upload.js",
+    "upload:oxide": "yarn build && ts-node ./scripts/upload-oxide.ts"
   },
   "devDependencies": {
     "@types/node": "^10.11.6",
+    "@types/node-fetch": "2.5.5",
     "css-loader": "^1.0.0",
     "html-webpack-inline-source-plugin": "^0.0.10",
     "html-webpack-plugin": "^3.2.0",
+    "node-fetch": "2.6.0",
     "node-sass": "^4.13.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "superagent": "^4.0.0-beta.5",
     "ts-loader": "^5.2.1",
+    "ts-node": "8.8.1",
     "typescript": "^3.1.1",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2",

--- a/scripts/upload-oxide.ts
+++ b/scripts/upload-oxide.ts
@@ -1,0 +1,197 @@
+import fetch from 'node-fetch';
+import * as yaml from 'yaml';
+import * as fs from 'fs';
+
+type GitHubSource = {
+    type: 'GITHUB';
+    properties: {
+        owner: string;
+        repo: string;
+    };
+};
+
+type InternalSource = {
+    type: 'INTERNAL';
+    properties: {
+        id: string;
+    };
+};
+
+type Source = InternalSource | GitHubSource;
+
+// ---
+
+type TokenResponse = {
+    token: string;
+    source_metadata: Source; // targets the GitHub repository.
+}
+const getSourceMetadataForApp = async (token, appId) => {
+    const editorBasePath = `https://build.journeyapps.com/api/v4/apps/${appId}`;
+    const response = await fetch(`${editorBasePath}/files/issue_jwt`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
+    });
+    const tokenResponse: TokenResponse = await response.json();
+    return tokenResponse
+};
+
+// ---
+type Author = {
+    name: string;
+    email: string;
+}
+
+type FileModified = {
+    type: "modified";
+    path: string;
+    content: string; // base64 encoded
+}
+
+type FileDeleted = {
+    type: "deleted";
+    path: string;
+}
+
+type Delta = FileModified | FileDeleted;
+
+type LatestCommitResponse = {
+    data: {
+        oid: string; // the commit ID
+        author: Author;
+        committer: Author;
+        timestamp: string;
+        message: string;
+    }
+}
+
+
+type SingleCommit = {
+    oid: string;
+    author: Author;
+    committer: Author;
+    timestamp: string;
+    message: string;
+};
+
+type CommitPayload = {
+    author: {
+        email: string;
+        name: string;
+    };
+    delta: Delta[]; // an array of operations
+    message: string; // commit message
+    branch: string; // the branch to commit against
+    ref: string; // a committish the delta is operating on
+    source: Source;
+}
+
+export type V2CommitResponseClean = {
+    success: true;
+    commit: SingleCommit;
+};
+
+export type V2CommitResponseDirty = {
+    success: false;
+    conflicts: string[];
+};
+
+export type V2CommitResponse = V2CommitResponseClean | V2CommitResponseDirty;
+
+
+const commitFilesToHEAD = async (token: string, payload: Omit<CommitPayload, 'ref'>) => {
+    const { source, branch, delta, message, author } = payload;
+    const headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+    };
+
+    const get_latest_commit_res = await fetch("https://source.journeyapps.com/api/v1/sources/get-latest-commit",
+        {
+            headers,
+            method: "POST",
+            body: JSON.stringify({
+                source: source,
+                branch: branch
+            })
+        });
+
+    const latest_commit_oid = (await get_latest_commit_res.json() as LatestCommitResponse).data.oid; // Or something like this.
+
+    console.log(`Committing to branch '${branch}'.`);
+
+    const commitPayload: CommitPayload = {
+        source: source,
+        branch: branch, // Branch to which to commit.
+        ref: latest_commit_oid, // The commit we're basing off.
+        delta: delta,
+        message: message,
+        author: author
+    };
+
+    const commit_res = await fetch("https://source.journeyapps.com/api/v2/sources/commit", {
+        headers: headers,
+        method: "POST",
+        body: JSON.stringify(commitPayload)
+    });
+
+    if (commit_res.ok) {
+        const data = (await commit_res.json()).data as V2CommitResponse;
+
+        if (data.success === true) {
+            console.log(data.commit)
+        } else {
+            console.error('Conflict:');
+            console.error(data.conflicts);
+        }
+        return data;
+    } else {
+        throw `Commit error response: ${commit_res.status} ${commit_res.statusText}.`;
+    }
+};
+
+
+const assembleBundle = (outputFileName) => {
+    const fileData = fs.readFileSync('dist/' + outputFileName);
+
+    const delta: Delta[] = [
+        {
+            type: "modified",
+            path: `mobile/html/${outputFileName}`,
+            content: fileData.toString("base64")
+        }
+    ];
+    return delta;
+};
+
+
+async function main() {
+    const config = yaml.parse(fs.readFileSync('config.yml', 'utf8'));
+
+    const { appId, outputFileName, branch, gitName, gitEmail } = config;
+
+    if (!(gitEmail || gitName)) {
+        console.error('Missing your Name and Email for git commits');
+        throw('Missing git author configuration');
+    }
+
+    const editorToken = config.token;
+
+    const { source_metadata, token } = await getSourceMetadataForApp(editorToken, appId);
+
+    const delta = assembleBundle(outputFileName);
+
+    const result = await commitFilesToHEAD(token,  {
+        source: source_metadata,
+        author: {
+            name: gitName,
+            email: gitEmail
+        },
+        branch: branch ? branch : 'master',
+        message: 'Updating HTML-Bridge component.',
+        delta: delta
+    });
+}
+
+main().catch(e => console.error(e));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@types/node-fetch@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.5.tgz#cd264e20a81f4600a6c52864d38e7fef72485e92"
+  integrity sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node@*":
+  version "12.12.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.31.tgz#d6b4f9645fee17f11319b508fb1001797425da51"
+  integrity sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==
+
 "@types/node@^10.11.6":
   version "10.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.6.tgz#ce5690df6cd917a9178439a1013e39a7e565c46e"
@@ -218,6 +231,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -641,6 +659,13 @@ combined-stream@1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
@@ -909,6 +934,11 @@ des.js@^1.0.0:
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -1223,6 +1253,15 @@ form-data@^2.3.2, form-data@~2.3.2:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 formidable@^1.2.0:
@@ -1938,6 +1977,11 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 map-age-cleaner@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz#098fb15538fd3dbe461f12745b0ca8568d4e3f74"
@@ -2178,6 +2222,11 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -3072,6 +3121,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.6:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -3086,7 +3143,7 @@ source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -3362,6 +3419,17 @@ ts-loader@^5.2.1:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
+ts-node@8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.1.tgz#7c4d3e9ed33aa703b64b28d7f9d194768be5064d"
+  integrity sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "3.1.1"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -3385,8 +3453,9 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -3698,3 +3767,8 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
The `yarn upload:oxide` tool commits directly to configured branch. It does not affect any active drafts. To avoid confusion, ensure that you have closed (committed or discarded) any drafts belonging to you, the developer token holder

You will need to deploy via Oxide afterwards, to see the changes in app.